### PR TITLE
Loggin improvements

### DIFF
--- a/setup-cron.sh
+++ b/setup-cron.sh
@@ -3,19 +3,16 @@
 CRON_FILE="cron.conf"
 SERVICE_FILE="service.sh"
 TEMPORARY_CRONTAB="crontab.tmp"
-CRON_DIR="/var/spool/cron/crontabs"
-USER="root"
 
-touch $TEMPORARY_CRONTAB
+echo "" > $TEMPORARY_CRONTAB
 
 for dir in `ls schedules`; do
 	path="$PWD/schedules/$dir"
 
-	if [ -d  $path ]
+	if [ -d "$path" ]
 	then
-		touch TEMPORARY_CRONTAB
-		paste -d' ' <(cat $path/$CRON_FILE) <(echo "$path/$SERVICE_FILE") >> $TEMPORARY_CRONTAB
+    paste -d' ' <(cat "$path/$CRON_FILE") <(echo "$path/$SERVICE_FILE") <(echo ">/dev/null 2>&1") >> $TEMPORARY_CRONTAB
 	fi
 done
 
-mv -f $TEMPORARY_CRONTAB $CRON_DIR/$USER
+crontab $TEMPORARY_CRONTAB

--- a/write-log
+++ b/write-log
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+LOG_GROUP=scheduler
+STREAM=test-stream
+if [ $# -ge 1 ]; then
+        STREAM=$1
+fi
+MESSAGE=${*:2}
+
+docker run --rm -d \
+        --log-driver=awslogs \
+        --log-opt awslogs-group="$LOG_GROUP" \
+        --log-opt awslogs-stream="$STREAM" \
+        cogniteev/echo \
+        echo "$MESSAGE" \
+        >/dev/null


### PR DESCRIPTION
Adicionado programa `write-log` para escrever logs no CloudWatch

Melhorado o `setup-cron.sh` para usar o comando `crontab` ao invés de copiar o arquivo temporáirio